### PR TITLE
Use criproxy on Milpa workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ SSH into the master node and check the status of the cluster:
     ip-10-0-100-66    Ready    master   97s   v1.14.0
     ubuntu@ip-10-0-100-66:~$
 
-At this point, the cluster is ready to use. Pods will be scheduled to run in EC2 instances, instead of containers on the worker node.
+At this point, the cluster is ready to use.
+
+To schedule pods via Milpa, you have to add an annotation:
+
+    ubuntu@ip-10-0-100-66:~$ kubectl run nginx --image=nginx --overrides='{"apiVersion": "apps/v1", "spec":{ "template":{ "metadata": { "annotations":{"kubernetes.io/target-runtime":"kiyot"} }, "spec": { "nodeSelector": {"kubernetes.io/role": "milpa-worker"} } } } }'
+
+If you have both Milpa and non-Milpa workers in your cluster, you will also have to add a `nodeSelector` as above, otherwise pods will also be scheduled to run on non-Milpa workers.
 
 ## Teardown
 

--- a/master.sh
+++ b/master.sh
@@ -83,3 +83,61 @@ EOF
 kubectl create -n kube-system configmap ip-masq-agent --from-file=/tmp/ip-masq-agent-config/config
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/ip-masq-agent.yaml
 kubectl patch -n kube-system daemonset ip-masq-agent --patch '{"spec":{"template":{"spec":{"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}]}}}}'
+
+# Start a kube-proxy deployment for Milpa. This will route cluster IP traffic
+# from Milpa pods.
+cat <<EOF > /tmp/kube-proxy-milpa.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: kube-proxy
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      annotations:
+        kubernetes.io/target-runtime: kiyot
+    spec:
+      nodeSelector:
+        kubernetes.io/role: milpa-worker
+      containers:
+      - command:
+        - /usr/local/bin/kube-proxy
+        - --config=/var/lib/kube-proxy/config.conf
+        - --hostname-override=$(NODE_NAME)
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: k8s.gcr.io/kube-proxy:v1.15.0
+        name: kube-proxy
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/kube-proxy
+          name: kube-proxy
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext: {}
+      serviceAccount: kube-proxy
+      serviceAccountName: kube-proxy
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: kube-proxy
+        name: kube-proxy
+EOF
+kubectl apply -f /tmp/kube-proxy-milpa.yaml

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -65,6 +65,7 @@ EOF
 systemctl daemon-reload
 systemctl restart criproxy
 
+# Configure kubelet.
 name=""
 while [[ -z "$name" ]]; do
     sleep 1

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -5,7 +5,65 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io python-pip jq
+apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni containerd python-pip jq
+
+# Configure containerd. This assumes kubenet is used for networking.
+modprobe br_netfilter
+sysctl net.bridge.bridge-nf-call-iptables=1; echo "net.bridge.bridge-nf-call-iptables=1" >> /etc/sysctl.conf
+sysctl net.ipv4.ip_forward=1; echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+mkdir -p /etc/cni/net.d
+mkdir -p /etc/containerd
+cat <<EOF > /etc/containerd/config.toml
+[plugins.cri]
+  [plugins.cri.cni]
+    conf_template = "/etc/containerd/cni-template.json"
+EOF
+cat <<EOF > /etc/containerd/cni-template.json
+{
+  "cniVersion": "0.3.1",
+  "name": "containerd-net",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "subnet": "{{.PodCIDR}}",
+        "routes": [
+          { "dst": "0.0.0.0/0" }
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+EOF
+systemctl restart containerd
+
+# Install criproxy.
+curl -L https://milpa-builds.s3.amazonaws.com/criproxy > /usr/local/bin/criproxy; chmod 755 /usr/local/bin/criproxy
+cat <<EOF > /etc/systemd/system/criproxy.service
+[Unit]
+Description=CRI Proxy
+Wants=containerd.service
+
+[Service]
+ExecStart=/usr/local/bin/criproxy -v 3 -logtostderr -connect /run/containerd/containerd.sock,kiyot:/opt/milpa/run/kiyot.sock -listen /run/criproxy.sock
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=kubelet.service
+EOF
+systemctl daemon-reload
+systemctl restart criproxy
 
 name=""
 while [[ -z "$name" ]]; do
@@ -23,35 +81,33 @@ discovery:
     apiServerEndpoint: ${masterIP}:6443
 nodeRegistration:
   name: $name
-#  criSocket: unix:///opt/milpa/run/kiyot.sock
+  criSocket: unix:///run/criproxy.sock
   kubeletExtraArgs:
     cloud-provider: aws
+    network-plugin: kubenet
+    non-masquerade-cidr: 0.0.0.0/0
     max-pods: "1000"
     node-labels: kubernetes.io/role=milpa-worker
 EOF
 
+# Install milpa and kiyot.
 curl -L ${milpa_installer_url} > milpa-installer-latest
 chmod 755 milpa-installer-latest
 ./milpa-installer-latest
 
+# Configure milpa and kiyot.
 pip install yq
 yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .nodes.extraCIDRs=[\"${pod_cidr}\"] | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
 sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --service-cluster-ip-range ${service_cidr} --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
 sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml --delete-cluster-lock-file#' /etc/systemd/system/milpa.service
+
+# Ensure systemd will keep restarting kubelet.
 mkdir -p /etc/systemd/system/kubelet.service.d/
 echo -e "[Service]\nStartLimitInterval=0\nStartLimitIntervalSec=0\nRestart=always\nRestartSec=5" > /etc/systemd/system/kubelet.service.d/override.conf
 
 for i in {1..50}; do kubeadm join --config=/tmp/kubeadm-config.yaml && break || sleep 15; done
 
-# TODO: have kiyot retry creating k8s client and connect to the API server, and
-# have kubeadm configure the CRI. Then we can override all the extra parameters
-# via kubeletExtraArgs, and don't need to update kubeadm-flags.env here.
-echo "KUBELET_KUBEADM_ARGS=--cloud-provider=aws --hostname-override=$(hostname -f) --cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=unix:///opt/milpa/run/kiyot.sock --max-pods=1000" > /var/lib/kubelet/kubeadm-flags.env
-
 systemctl daemon-reload
 systemctl restart milpa
 systemctl restart kiyot
 systemctl restart kubelet
-
-docker ps -aq --no-trunc | xargs docker stop
-docker ps -aq --no-trunc | xargs docker rm


### PR DESCRIPTION
The main change here is to install criproxy, which will create pods/containers etc via containerd on milpa workers, and only use kiyot/milpa if a pod is annotated with `"kubernetes.io/target-runtime":"kiyot"`.