### PR TITLE
Add support for CNI plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ If you have both Milpa and non-Milpa workers in your cluster, you can also use a
       nodeSelector:
         mycompany.com/worker: ""
 
+## Networking
+
+By default, kubenet is used. You can change this via setting the variable `network-plugin`. Currently `kubenet`, `kube-router`, `flannel` and `calico` are supported.
+
 ## Teardown
 
 Make sure all pods and services are removed. On the master:

--- a/env.tfvars.example
+++ b/env.tfvars.example
@@ -38,3 +38,11 @@ license-password = ""
 # Specify the number of Milpa worker nodes. Right now only 0 or 1 are
 # supported.
 #milpa-workers = 1
+
+# The Kubernetes network plugin to use. Accepted values are "kubenet",
+# "kube-router", "calico" and "flannel".
+#network-plugin = "kubenet"
+
+# Whether to create cloud routes for pod CIDRs allocated to nodes. Default is
+# "true".
+#configure-cloud-routes = "true"

--- a/main.tf
+++ b/main.tf
@@ -398,25 +398,27 @@ data "template_file" "master-userdata" {
   template = file(var.master-userdata)
 
   vars = {
-    k8stoken              = local.k8stoken
-    k8s_version           = var.k8s-version
-    pod_cidr              = var.pod-cidr
-    service_cidr          = var.service-cidr
-    subnet_cidrs          = join(" ", aws_subnet.subnets.*.cidr_block)
-    node_nametag          = var.cluster-name
-    aws_access_key_id     = var.aws-access-key-id
-    aws_secret_access_key = var.aws-secret-access-key
-    aws_region            = var.region
-    default_instance_type = var.default-instance-type
-    default_volume_size   = var.default-volume-size
-    boot_image_tags       = jsonencode(var.boot-image-tags)
-    license_key           = var.license-key
-    license_id            = var.license-id
-    license_username      = var.license-username
-    license_password      = var.license-password
-    itzo_url              = var.itzo-url
-    itzo_version          = var.itzo-version
-    milpa_image           = var.milpa-image
+    k8stoken                = local.k8stoken
+    k8s_version             = var.k8s-version
+    pod_cidr                = var.pod-cidr
+    service_cidr            = var.service-cidr
+    subnet_cidrs            = join(" ", aws_subnet.subnets.*.cidr_block)
+    node_nametag            = var.cluster-name
+    aws_access_key_id       = var.aws-access-key-id
+    aws_secret_access_key   = var.aws-secret-access-key
+    aws_region              = var.region
+    default_instance_type   = var.default-instance-type
+    default_volume_size     = var.default-volume-size
+    boot_image_tags         = jsonencode(var.boot-image-tags)
+    license_key             = var.license-key
+    license_id              = var.license-id
+    license_username        = var.license-username
+    license_password        = var.license-password
+    itzo_url                = var.itzo-url
+    itzo_version            = var.itzo-version
+    milpa_image             = var.milpa-image
+    network_plugin          = var.network-plugin
+    configure_cloud_routes  = var.configure-cloud-routes
   }
 }
 
@@ -424,9 +426,10 @@ data "template_file" "milpa-worker-userdata" {
   template = file(var.milpa-worker-userdata)
 
   vars = {
-    k8stoken    = local.k8stoken
-    k8s_version = var.k8s-version
-    masterIP    = aws_instance.k8s-master.private_ip
+    k8stoken        = local.k8stoken
+    k8s_version     = var.k8s-version
+    masterIP        = aws_instance.k8s-master.private_ip
+    network_plugin  = var.network-plugin
   }
 }
 
@@ -434,10 +437,10 @@ data "template_file" "worker-userdata" {
   template = file(var.worker-userdata)
 
   vars = {
-    k8stoken    = local.k8stoken
-    k8s_version = var.k8s-version
-    masterIP    = aws_instance.k8s-master.private_ip
-    pod_cidr    = var.pod-cidr
+    k8stoken        = local.k8stoken
+    k8s_version     = var.k8s-version
+    masterIP        = aws_instance.k8s-master.private_ip
+    network_plugin  = var.network-plugin
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -466,14 +466,11 @@ resource "aws_instance" "k8s-master" {
   associate_public_ip_address = true
   vpc_security_group_ids      = [aws_security_group.kubernetes.id]
   iam_instance_profile        = aws_iam_instance_profile.k8s-master.id
+  source_dest_check           = false
 
   depends_on = [aws_internet_gateway.gw]
 
   tags = merge(local.k8s_cluster_tags, local.k8s_milpa_master_tag)
-
-  lifecycle {
-    ignore_changes = [source_dest_check]
-  }
 }
 
 locals {
@@ -491,6 +488,7 @@ resource "aws_instance" "k8s-milpa-worker" {
   associate_public_ip_address = true
   vpc_security_group_ids      = [aws_security_group.kubernetes.id]
   iam_instance_profile        = aws_iam_instance_profile.k8s-milpa-worker.id
+  source_dest_check           = false
 
   root_block_device {
     volume_size = var.worker-disk-size
@@ -516,13 +514,6 @@ resource "aws_instance" "k8s-milpa-worker" {
       "AWS_DEFAULT_REGION" = var.region
     }
   }
-
-  lifecycle {
-    # This seems like a bug in Terraform or the AWS provider - even though
-    # userdata is the same, TF thinks it has changed, which forces a
-    # replacement of the instance. Let's ignore userdata changes for now.
-    ignore_changes = [source_dest_check]
-  }
 }
 
 resource "aws_instance" "k8s-worker" {
@@ -535,6 +526,7 @@ resource "aws_instance" "k8s-worker" {
   associate_public_ip_address = true
   vpc_security_group_ids      = [aws_security_group.kubernetes.id]
   iam_instance_profile        = aws_iam_instance_profile.k8s-worker.id
+  source_dest_check           = false
 
   root_block_device {
     volume_size = var.worker-disk-size
@@ -543,8 +535,4 @@ resource "aws_instance" "k8s-worker" {
   depends_on = [aws_internet_gateway.gw]
 
   tags = merge(local.k8s_cluster_tags, local.k8s_milpa_worker_tag)
-
-  lifecycle {
-    ignore_changes = [source_dest_check]
-  }
 }

--- a/master.sh
+++ b/master.sh
@@ -59,8 +59,10 @@ nodeRegistration:
   name: $name
   kubeletExtraArgs:
     cloud-provider: aws
-    network-plugin: kubenet
-    non-masquerade-cidr: 0.0.0.0/0
+$(if [[ "${network_plugin}" = "kubenet" ]]; then
+    echo '    network-plugin: kubenet'
+    echo '    non-masquerade-cidr: 0.0.0.0/0'
+fi)
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration

--- a/master.sh
+++ b/master.sh
@@ -98,6 +98,11 @@ mkdir -p /home/ubuntu/.kube
 sudo cp -i $KUBECONFIG /home/ubuntu/.kube/config
 sudo chown ubuntu: /home/ubuntu/.kube/config
 
+# Networking.
+if [[ "${network_plugin}" != "kubenet" ]]; then
+    curl -fL https://raw.githubusercontent.com/elotl/milpa-deploy/master/deploy/cni/${network_plugin}.yaml | envsubst | kubectl apply -f -
+fi
+
 # Create a default storage class, backed by EBS.
 curl -fL https://raw.githubusercontent.com/elotl/milpa-deploy/master/deploy/storageclass-ebs.yaml | envsubst | kubectl apply -f -
 

--- a/master.sh
+++ b/master.sh
@@ -74,9 +74,13 @@ apiServer:
 controllerManager:
   extraArgs:
     cloud-provider: aws
-    configure-cloud-routes: "true"
+$(if [[ "${configure_cloud_routes}" = "true" ]]; then
+    echo '    configure-cloud-routes: "true"'
+else
+    echo '    configure-cloud-routes: "false"'
+fi)
     address: 0.0.0.0
-kubernetesVersion: "${k8s_version}"
+kubernetesVersion: "$k8s_version"
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -30,7 +30,7 @@ EOF
       "type": "bridge",
       "bridge": "cni0",
       "isGateway": true,
-      "ipMasq": true,
+      "ipMasq": false,
       "promiscMode": true,
       "ipam": {
         "type": "host-local",

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -48,6 +48,7 @@ EOF
 }
 EOF
 fi
+systemctl enable containerd
 systemctl restart containerd
 
 # Install criproxy.
@@ -67,6 +68,7 @@ RestartSec=10
 WantedBy=kubelet.service
 EOF
 systemctl daemon-reload
+systemctl enable criproxy
 systemctl restart criproxy
 
 # Configure kubelet.
@@ -130,7 +132,8 @@ ExecStop=/bin/umount /proc/meminfo
 StandardOutput=journal
 EOF
 systemctl daemon-reload
-systemctl start kiyot-override-proc
+systemctl enable kiyot-override-proc
+systemctl restart kiyot-override-proc
 
 # Join cluster.
 kubeadm join --config=/tmp/kubeadm-config.yaml

--- a/variables.tf
+++ b/variables.tf
@@ -158,3 +158,11 @@ variable "milpa-image" {
 variable "milpa-worker-ami" {
   default = ""
 }
+
+variable "network-plugin" {
+  default = "kubenet"
+}
+
+variable "configure-cloud-routes" {
+  default = "true"
+}

--- a/worker.sh
+++ b/worker.sh
@@ -28,8 +28,10 @@ nodeRegistration:
   name: $name
   kubeletExtraArgs:
     cloud-provider: aws
-    network-plugin: kubenet
-    non-masquerade-cidr: 0.0.0.0/0
+$(if [[ "${network_plugin}" = "kubenet" ]]; then
+    echo "    network-plugin: kubenet"
+    echo "    non-masquerade-cidr: 0.0.0.0/0"
+fi)
 EOF
 
 kubeadm join --config=/tmp/kubeadm-config.yaml


### PR DESCRIPTION
This allows the user to choose a CNI plugin for pod networking. Currently, the following plugins are supported:
- kubenet (the old default),
- flannel,
- calico and
- kube-router.

It should not be too hard to support other plugins either, the only requirement is that the plugin is able to use the pod CIDR allocated to nodes by the control plane.